### PR TITLE
Update bindgen and fix include search dirs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.52.0
+          - 1.60.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -38,7 +38,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.52.0
+          - 1.60.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  BINDGEN_EXTRA_CLANG_ARGS: "-I/usr/include/scotch"
 
 jobs:
   check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ keywords = ["graph", "mesh", "matrix", "partitioning", "ordering"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scotch-sys = "0.1"
+scotch-sys = { version = "0.1", path = "scotch-sys" }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Idiomatic bindings to the [Scotch] partitioner.
 Prerequisites:
 
 - Scotch
-- clang v3.9 or above
+- clang v5.0 or above
 
 Bindings to Scotch are made on the fly.  If Scotch is installed in a
 non-standard location, please use the following commands:

--- a/scotch-sys/Cargo.toml
+++ b/scotch-sys/Cargo.toml
@@ -14,4 +14,4 @@ keywords = ["graph", "mesh", "matrix", "partitioning", "ordering"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-bindgen = { version = "0.58", default-features = false }
+bindgen = { version = "0.65", default-features = false }

--- a/scotch-sys/build.rs
+++ b/scotch-sys/build.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process;
 
@@ -6,6 +7,13 @@ fn main() {
     println!("cargo:rustc-link-lib=scotch");
     println!("cargo:rustc-link-lib=scotcherr");
     println!("cargo:rerun-if-changed=wrapper.h");
+
+    let mut cpath = env::var_os("CPATH").unwrap_or_else(OsString::new);
+    if !cpath.is_empty() {
+        cpath.push(":");
+    }
+    cpath.push("/usr/include/scotch");
+    env::set_var("CPATH", cpath);
 
     let bindings = bindgen::builder()
         .header("wrapper.h")

--- a/scotch-sys/build.rs
+++ b/scotch-sys/build.rs
@@ -10,8 +10,8 @@ fn main() {
     let bindings = bindgen::builder()
         .header("wrapper.h")
         .generate()
-        .unwrap_or_else(|()| {
-            eprintln!("Failed to generate bindings to Scotch");
+        .unwrap_or_else(|err| {
+            eprintln!("Failed to generate bindings to Scotch: {err}");
             process::exit(1);
         });
 


### PR DESCRIPTION
Also search for `/usr/include/scotch`, since that's where scotch.h is on ubuntu