### PR TITLE
Bump scotch target version to 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         rust:
@@ -32,7 +32,7 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         rust:
@@ -52,7 +52,7 @@ jobs:
 
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -68,7 +68,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   rustdoc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ compile_error!("Scotch is only supported on UNIX platforms");
 #[test]
 fn bindings_are_for_the_correct_version_of_scotch() {
     const BINDINGS_VERSION: u32 = 6;
-    const BINDINGS_RELEASE: u32 = 0;
+    const BINDINGS_RELEASE: u32 = 1;
     assert!(
         s::SCOTCH_VERSION == BINDINGS_VERSION && s::SCOTCH_RELEASE == BINDINGS_RELEASE,
         "Rust bindings to Scotch have been made for Scotch {}.{}, your version of Scotch is {}.{}",


### PR DESCRIPTION
No (documented) API-breaking changes from 6.0 to 6.1:

> The k-way refinement routine of the module that computes graph
> partitions with overlap has been completely rewritten.
>
> The halo minimum degree and halo minimum fill algorithms now take into
> account, for computing vertex degrees, the vertex weights attached to node
> vertices. These weights may represent the number of degrees of freedom associ-
> ated with a vertex during subsequent matrix computations. They can result from
> a graph compression process, such as the one implemented in Scotch (see page 73).
>
> The program gout can now output VTK files.

We might want this test to succeed on 6.0 too. Maybe in another patch.